### PR TITLE
feature/skip-exporter-columns-selection

### DIFF
--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -126,7 +126,7 @@ ExportColumn::make('description')
 
 ### Disabling column selection
 
-By default, user will be asked which columns they would like to export. You can disable this functionality by passing `null` to `form()` method:
+By default, user will be asked which columns they would like to export. You can disable this functionality with the `columnMapping()` method:
 
 ```php
 use App\Filament\Exports\ProductExporter;
@@ -134,7 +134,7 @@ use Filament\Actions\ExportAction;
 
 ExportAction::make()
     ->exporter(ProductExporter::class)
-    ->form(null)
+    ->columnMapping(false)
 ```
 
 ### Calculated export column state

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -126,11 +126,10 @@ ExportColumn::make('description')
 
 ### Disabling column selection
 
-By default, user will be asked which columns they would like to export. You can disable this functionality with the `columnMapping()` method:
+By default, user will be asked which columns they would like to export. You can disable this functionality using `columnMapping(false)`:
 
 ```php
 use App\Filament\Exports\ProductExporter;
-use Filament\Actions\ExportAction;
 
 ExportAction::make()
     ->exporter(ProductExporter::class)

--- a/packages/actions/docs/07-prebuilt-actions/09-export.md
+++ b/packages/actions/docs/07-prebuilt-actions/09-export.md
@@ -124,6 +124,19 @@ ExportColumn::make('description')
     ->enabledByDefault(false)
 ```
 
+### Disabling column selection
+
+By default, user will be asked which columns they would like to export. You can disable this functionality by passing `null` to `form()` method:
+
+```php
+use App\Filament\Exports\ProductExporter;
+use Filament\Actions\ExportAction;
+
+ExportAction::make()
+    ->exporter(ProductExporter::class)
+    ->form(null)
+```
+
 ### Calculated export column state
 
 Sometimes you need to calculate the state of a column, instead of directly reading it from a database column.

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -61,6 +61,8 @@ trait CanExportRecords
 
     protected ?Closure $modifyQueryUsing = null;
 
+    protected bool $skippableSelection = false;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -73,13 +75,13 @@ trait CanExportRecords
 
         $this->groupedIcon(FilamentIcon::resolve('actions::export-action.grouped') ?? 'heroicon-m-arrow-down-tray');
 
-        $this->form(fn (ExportAction | ExportTableAction | ExportTableBulkAction $action): array => array_merge([
+        $this->form(fn(ExportAction|ExportTableAction|ExportTableBulkAction $action): array => array_merge([
             Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
                 ->columns(1)
                 ->inlineLabel()
                 ->schema(function () use ($action): array {
                     return array_map(
-                        fn (ExportColumn $column): Split => Split::make([
+                        fn(ExportColumn $column): Split => Split::make([
                             Forms\Components\Checkbox::make('isEnabled')
                                 ->label(__('filament-actions::export.modal.form.columns.form.is_enabled.label', ['column' => $column->getName()]))
                                 ->hiddenLabel()
@@ -91,8 +93,8 @@ trait CanExportRecords
                                 ->hiddenLabel()
                                 ->default($column->getLabel())
                                 ->placeholder($column->getLabel())
-                                ->disabled(fn (Forms\Get $get): bool => ! $get('isEnabled'))
-                                ->required(fn (Forms\Get $get): bool => (bool) $get('isEnabled')),
+                                ->disabled(fn(Forms\Get $get): bool => !$get('isEnabled'))
+                                ->required(fn(Forms\Get $get): bool => (bool)$get('isEnabled')),
                         ])
                             ->verticallyAlignCenter()
                             ->statePath($column->getName()),
@@ -100,7 +102,7 @@ trait CanExportRecords
                     );
                 })
                 ->statePath('columnMap'),
-        ], $action->getExporter()::getOptionsFormComponents()));
+            ], $action->getExporter()::getOptionsFormComponents()));
 
         $this->action(function (ExportAction | ExportTableAction | ExportTableBulkAction $action, array $data, Component $livewire) {
             if ($livewire instanceof HasTable) {
@@ -139,14 +141,20 @@ trait CanExportRecords
                 Arr::except($data, ['columnMap']),
             );
 
-            $columnMap = collect($data['columnMap'])
-                ->dot()
-                ->reduce(fn (Collection $carry, mixed $value, string $key): Collection => $carry->mergeRecursive([
-                    Str::beforeLast($key, '.') => [Str::afterLast($key, '.') => $value],
-                ]), collect())
-                ->filter(fn (array $column): bool => $column['isEnabled'] ?? false)
-                ->mapWithKeys(fn (array $column, string $columnName): array => [$columnName => $column['label']])
-                ->all();
+            if ($this->skippableSelection) {
+                $columnMap = collect($action->getExporter()::getColumns())
+                    ->mapWithKeys(fn(ExportColumn $column): array => [$column->getName() => $column->getLabel()]
+                )->all();
+            } else {
+                $columnMap = collect($data['columnMap'])
+                    ->dot()
+                    ->reduce(fn(Collection $carry, mixed $value, string $key): Collection => $carry->mergeRecursive([
+                        Str::beforeLast($key, '.') => [Str::afterLast($key, '.') => $value],
+                    ]), collect())
+                    ->filter(fn(array $column): bool => $column['isEnabled'] ?? false)
+                    ->mapWithKeys(fn(array $column, string $columnName): array => [$columnName => $column['label']])
+                    ->all();
+            }
 
             $export = app(Export::class);
             $export->user()->associate($user);
@@ -384,6 +392,13 @@ trait CanExportRecords
     public function modifyQueryUsing(?Closure $callback): static
     {
         $this->modifyQueryUsing = $callback;
+
+        return $this;
+    }
+
+    public function skippableSelection(bool $skippable = true): static
+    {
+        $this->skippableSelection = $skippable;
 
         return $this;
     }

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -61,8 +61,6 @@ trait CanExportRecords
 
     protected ?Closure $modifyQueryUsing = null;
 
-    protected bool $skippableSelection = false;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -141,7 +139,7 @@ trait CanExportRecords
                 Arr::except($data, ['columnMap']),
             );
 
-            if ($this->skippableSelection) {
+            if (! $this->form) {
                 $columnMap = collect($action->getExporter()::getColumns())
                     ->mapWithKeys(fn(ExportColumn $column): array => [$column->getName() => $column->getLabel()]
                 )->all();
@@ -392,13 +390,6 @@ trait CanExportRecords
     public function modifyQueryUsing(?Closure $callback): static
     {
         $this->modifyQueryUsing = $callback;
-
-        return $this;
-    }
-
-    public function skippableSelection(bool $skippable = true): static
-    {
-        $this->skippableSelection = $skippable;
 
         return $this;
     }

--- a/packages/actions/src/Concerns/CanExportRecords.php
+++ b/packages/actions/src/Concerns/CanExportRecords.php
@@ -73,13 +73,13 @@ trait CanExportRecords
 
         $this->groupedIcon(FilamentIcon::resolve('actions::export-action.grouped') ?? 'heroicon-m-arrow-down-tray');
 
-        $this->form(fn(ExportAction|ExportTableAction|ExportTableBulkAction $action): array => array_merge([
+        $this->form(fn (ExportAction | ExportTableAction | ExportTableBulkAction $action): array => array_merge([
             Fieldset::make(__('filament-actions::export.modal.form.columns.label'))
                 ->columns(1)
                 ->inlineLabel()
                 ->schema(function () use ($action): array {
                     return array_map(
-                        fn(ExportColumn $column): Split => Split::make([
+                        fn (ExportColumn $column): Split => Split::make([
                             Forms\Components\Checkbox::make('isEnabled')
                                 ->label(__('filament-actions::export.modal.form.columns.form.is_enabled.label', ['column' => $column->getName()]))
                                 ->hiddenLabel()
@@ -91,8 +91,8 @@ trait CanExportRecords
                                 ->hiddenLabel()
                                 ->default($column->getLabel())
                                 ->placeholder($column->getLabel())
-                                ->disabled(fn(Forms\Get $get): bool => !$get('isEnabled'))
-                                ->required(fn(Forms\Get $get): bool => (bool)$get('isEnabled')),
+                                ->disabled(fn (Forms\Get $get): bool => ! $get('isEnabled'))
+                                ->required(fn (Forms\Get $get): bool => (bool) $get('isEnabled')),
                         ])
                             ->verticallyAlignCenter()
                             ->statePath($column->getName()),
@@ -100,7 +100,7 @@ trait CanExportRecords
                     );
                 })
                 ->statePath('columnMap'),
-            ], $action->getExporter()::getOptionsFormComponents()));
+        ], $action->getExporter()::getOptionsFormComponents()));
 
         $this->action(function (ExportAction | ExportTableAction | ExportTableBulkAction $action, array $data, Component $livewire) {
             if ($livewire instanceof HasTable) {


### PR DESCRIPTION
## Description
Allow to skip columns selection form on Export Action by passing `null` value to `form()` method to export columns without displaying/filling selection form.

- [ ] Visual changes (if any) are shown using screenshots/recordings of before and after.

## Code style

<!-- Make sure code style follows the rest of the codebase. -->

- [X] `composer cs` command has been run.

## Testing

<!-- Ensure changes in this PR don't break existing functionality by testing it properly, either manually or by adding software tests. -->

- [X] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [X] Documentation is up-to-date.
